### PR TITLE
Modify context-menu markup and style on the fly

### DIFF
--- a/src/senaite/lims/browser/bootstrap/static/coffee/bootstrap-integration.coffee
+++ b/src/senaite/lims/browser/bootstrap/static/coffee/bootstrap-integration.coffee
@@ -8,6 +8,27 @@
 $(document).ready ->
   console.log '** SENAITE BOOTSTRAP INTEGRATION **'
 
+  # https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
+  observer = new MutationObserver (mutations) ->
+    $.each mutations, (index, record) ->
+      # watch added nodes
+      $.each record.addedNodes, (index, el) ->
+        $(document).trigger "onCreate", el
+
+  # Observe the document.body for future added elements
+  observer.observe document.body,
+    childList: yes
+    subtree: yes
+
+  # some on-the-fly modificaitons on dynamically created elements
+  $(document).on "onCreate", (event, el) ->
+    $el = $(el)
+    if $el.hasClass "tooltip"
+      $el.addClass "bottom bika-tooltip"
+      $el.wrapInner "<div class='tooltip-inner'></div>"
+      $el.append "<div class='tooltip-arrow'></div>"
+
+
   # Show new loader on Ajax events
   $(document).on
     ajaxStart: ->

--- a/src/senaite/lims/browser/bootstrap/static/css/bootstrap-integration.css
+++ b/src/senaite/lims/browser/bootstrap/static/css/bootstrap-integration.css
@@ -58,6 +58,10 @@ div.field.error {
 .bika-tooltip .tooltip-inner {
     background-color: white;
     color: black;
+    text-align: left;
+}
+.bika-tooltip .tooltip-inner table th {
+    border-bottom: 2px solid #f7f7f7;
 }
 .bika-tooltip .tooltip-arrow {
     border-bottom-color: white!important;

--- a/src/senaite/lims/browser/bootstrap/static/css/bootstrap-integration.css
+++ b/src/senaite/lims/browser/bootstrap/static/css/bootstrap-integration.css
@@ -50,6 +50,24 @@ div.field.error {
 #bika-spinner {
     display: none!important;
 }
+.bika-tooltip {
+    opacity: 1;
+    border: none!important;
+    background-color: transparent!important;
+}
+.bika-tooltip .tooltip-inner {
+    background-color: white;
+    color: black;
+}
+.bika-tooltip .tooltip-arrow {
+    border-bottom-color: white!important;
+}
+.bika-tooltip td {
+    cursor: pointer;
+}
+.bika-tooltip td:hover {
+    color: #337ab7;
+}
 /* /Loader */
 
 

--- a/src/senaite/lims/browser/bootstrap/static/js/bootstrap-integration.js
+++ b/src/senaite/lims/browser/bootstrap/static/js/bootstrap-integration.js
@@ -8,8 +8,28 @@
 
 (function() {
   $(document).ready(function() {
-    var foundPrimary, hiddenviewlet;
+    var foundPrimary, hiddenviewlet, observer;
     console.log('** SENAITE BOOTSTRAP INTEGRATION **');
+    observer = new MutationObserver(function(mutations) {
+      return $.each(mutations, function(index, record) {
+        return $.each(record.addedNodes, function(index, el) {
+          return $(document).trigger("onCreate", el);
+        });
+      });
+    });
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true
+    });
+    $(document).on("onCreate", function(event, el) {
+      var $el;
+      $el = $(el);
+      if ($el.hasClass("tooltip")) {
+        $el.addClass("bottom bika-tooltip");
+        $el.wrapInner("<div class='tooltip-inner'></div>");
+        return $el.append("<div class='tooltip-arrow'></div>");
+      }
+    });
     $(document).on({
       ajaxStart: function() {
         $('body').addClass('loading');


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Context menu in Bika listing views did not display on right-clicking the table header

## Current behavior before PR

Tooltip menu did not appear

## Desired behavior after PR is merged

Tooltip menu is BS styled and works properly

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
