### PR TITLE
Fixed missing reference browser widget in WS attachments viewlet

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -15,6 +15,8 @@
 
 **Fixed**
 
+- Added missing `attachments` CSS class to attachment templates
+
 **Security**
 
 

--- a/src/senaite/lims/browser/bootstrap/templates/bika.lims.browser.viewlets.templates.attachments.pt
+++ b/src/senaite/lims/browser/bootstrap/templates/bika.lims.browser.viewlets.templates.attachments.pt
@@ -1,4 +1,5 @@
 <div id="ar-attachments"
+     class="attachments"
      i18n:domain="bika">
 
   <p>

--- a/src/senaite/lims/browser/bootstrap/templates/bika.lims.browser.viewlets.templates.attachments.pt
+++ b/src/senaite/lims/browser/bootstrap/templates/bika.lims.browser.viewlets.templates.attachments.pt
@@ -106,7 +106,7 @@
                     </tal:item>
                   </select>
                 </td>
-                <td class="attachment-fiel-size">
+                <td class="attachment-field-size">
                   <!-- File Size -->
                   <span class="filesize" tal:content="attachment/size"></span>
                 </td>

--- a/src/senaite/lims/browser/bootstrap/templates/bika.lims.browser.viewlets.templates.worksheet_attachments.pt
+++ b/src/senaite/lims/browser/bootstrap/templates/bika.lims.browser.viewlets.templates.worksheet_attachments.pt
@@ -1,4 +1,5 @@
 <div id="ws-attachments"
+     class="attachments"
      i18n:domain="bika">
 
   <p>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds the missing `attachments` CSS class to the attachment viewlet templates, so that the JS triggers the reference browser widget for the Analysis field correctly

## Current behavior before PR

Reference Browser widget did not appear

## Desired behavior after PR is merged

Reference Browser widget appears on click into the Analyses field of WS Attachments

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
