### PR TITLE
Listings without row borders and stretched, with cleaner footer and header

### DIFF
--- a/src/senaite/lims/browser/bootstrap/static/coffee/bootstrap-integration.coffee
+++ b/src/senaite/lims/browser/bootstrap/static/coffee/bootstrap-integration.coffee
@@ -75,7 +75,8 @@ $(document).ready ->
   $('input[type="submit"], input[type="button"]').addClass 'btn btn-default'
 
   # Add table CSS classes
-  $('table').addClass 'table table-condensed table-bordered table-striped'
+  $('table').not('.bika-listing-table-container table').addClass 'table table-condensed table-bordered table-striped'
+  $('.bika-listing-table').addClass 'table table-condensed table-striped'
 
   # Convert all 'hiddenStructure' classes to 'hidden'
   $('.hiddenStructure').addClass 'hidden'
@@ -87,7 +88,7 @@ $(document).ready ->
 
   ### Form customizations ###
   $('form').addClass 'form'
-  $('input').addClass 'input-sm'
+  $('input').not('.bika-listing-table :checkbox').addClass 'input-sm'
   # $('form input[type=text]').addClass 'form-control'
   # $('form input[type=password]').addClass 'form-control'
   # $('form textarea').addClass 'form-control'

--- a/src/senaite/lims/browser/bootstrap/static/js/bootstrap-integration.js
+++ b/src/senaite/lims/browser/bootstrap/static/js/bootstrap-integration.js
@@ -61,7 +61,8 @@
     $('.worksheet_add_controls').addClass('form-inline');
     $('.datagridwidget-add-button').addClass('btn btn-default');
     $('input[type="submit"], input[type="button"]').addClass('btn btn-default');
-    $('table').addClass('table table-condensed table-bordered table-striped');
+    $('table').not('.bika-listing-table-container table').addClass('table table-condensed table-bordered table-striped');
+    $('.bika-listing-table').addClass('table table-condensed table-striped');
     $('.hiddenStructure').addClass('hidden');
     $('.template-manage-viewlets .hide').removeClass('hide');
     $('.template-manage-viewlets .show').removeClass('show');
@@ -71,7 +72,7 @@
 
     /* Form customizations */
     $('form').addClass('form');
-    $('input').addClass('input-sm');
+    $('input').not('.bika-listing-table :checkbox').addClass('input-sm');
     $('form select').addClass('input-sm');
     $('form textarea').attr('rows', 10);
     $('form div.formQuestion').removeClass('label');


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

With this pull request, the listings' rows are non-bordered, stretched, with cleaner footer and header. Other tables (e.g ar add, etc.) are not affected by this change.

## Current behavior before PR

![listing-old](https://user-images.githubusercontent.com/832627/34910019-d2a526a8-f8a4-11e7-86a6-eed0ac7a5dd9.png)


## Desired behavior after PR is merged

![listing-new](https://user-images.githubusercontent.com/832627/34910020-d88ec22c-f8a4-11e7-9f79-7928dc90aad3.png)


--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
