### PR TITLE
Better styling of slots and positions in Worksheet's classic view

### DIFF
--- a/src/senaite/lims/browser/bootstrap/static/coffee/bootstrap-integration.coffee
+++ b/src/senaite/lims/browser/bootstrap/static/coffee/bootstrap-integration.coffee
@@ -67,6 +67,11 @@ $(document).ready ->
 
   # Worksheets
   $('.worksheet_add_controls').addClass 'form-inline'
+  $('td.Pos').css('vertical-align', 'top')
+  $('td.Pos table.worksheet-position tbody tr').css('border', 'none')
+  $('td.Pos table.worksheet-position tbody tr td').css('vertical-align', 'top')
+  $('.bika-listing-table td.result.remarks').parent('tr').children('td').css('border', 'none')
+  $('.bika-listing-table td.result.remarks').css('padding-left', '23px')
 
   # Data Grid Field
   $('.datagridwidget-add-button').addClass 'btn btn-default'

--- a/src/senaite/lims/browser/bootstrap/static/coffee/bootstrap-integration.coffee
+++ b/src/senaite/lims/browser/bootstrap/static/coffee/bootstrap-integration.coffee
@@ -75,7 +75,8 @@ $(document).ready ->
   $('input[type="submit"], input[type="button"]').addClass 'btn btn-default'
 
   # Add table CSS classes
-  $('table').addClass 'table table-condensed table-bordered table-striped'
+  $('table').not('.bika-listing-table-container table').addClass 'table table-condensed table-bordered table-striped'
+  $('.bika-listing-table').addClass 'table table-condensed table-striped'
 
   # Convert all 'hiddenStructure' classes to 'hidden'
   $('.hiddenStructure').addClass 'hidden'
@@ -87,7 +88,7 @@ $(document).ready ->
 
   ### Form customizations ###
   $('form').addClass 'form'
-  $('input').addClass 'input-sm'
+  $('input').not('.bika-listing-table :checkbox').addClass 'input-sm'
   # $('form input[type=text]').addClass 'form-control'
   # $('form input[type=password]').addClass 'form-control'
   # $('form textarea').addClass 'form-control'

--- a/src/senaite/lims/browser/bootstrap/static/js/bootstrap-integration.js
+++ b/src/senaite/lims/browser/bootstrap/static/js/bootstrap-integration.js
@@ -59,6 +59,11 @@
     });
     $('table.ar-table td [fieldname]').addClass('form-inline');
     $('.worksheet_add_controls').addClass('form-inline');
+    $('td.Pos').css('vertical-align', 'top');
+    $('td.Pos table.worksheet-position tbody tr').css('border', 'none');
+    $('td.Pos table.worksheet-position tbody tr td').css('vertical-align', 'top');
+    $('.bika-listing-table td.result.remarks').parent('tr').children('td').css('border', 'none');
+    $('.bika-listing-table td.result.remarks').css('padding-left', '23px');
     $('.datagridwidget-add-button').addClass('btn btn-default');
     $('input[type="submit"], input[type="button"]').addClass('btn btn-default');
     $('table').not('.bika-listing-table-container table').addClass('table table-condensed table-bordered table-striped');

--- a/src/senaite/lims/browser/bootstrap/static/js/bootstrap-integration.js
+++ b/src/senaite/lims/browser/bootstrap/static/js/bootstrap-integration.js
@@ -61,7 +61,8 @@
     $('.worksheet_add_controls').addClass('form-inline');
     $('.datagridwidget-add-button').addClass('btn btn-default');
     $('input[type="submit"], input[type="button"]').addClass('btn btn-default');
-    $('table').addClass('table table-condensed table-bordered table-striped');
+    $('table').not('.bika-listing-table-container table').addClass('table table-condensed table-bordered table-striped');
+    $('.bika-listing-table').addClass('table table-condensed table-striped');
     $('.hiddenStructure').addClass('hidden');
     $('.template-manage-viewlets .hide').removeClass('hide');
     $('.template-manage-viewlets .show').removeClass('show');
@@ -71,7 +72,7 @@
 
     /* Form customizations */
     $('form').addClass('form');
-    $('input').addClass('input-sm');
+    $('input').not('.bika-listing-table :checkbox').addClass('input-sm');
     $('form select').addClass('input-sm');
     $('form textarea').attr('rows', 10);
     $('form div.formQuestion').removeClass('label');


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Make the styling of Worksheet's slots and positions cleaner

## Current behavior before PR

![ws-old](https://user-images.githubusercontent.com/832627/34910504-cf0dc70c-f8ae-11e7-82b9-14b0f16637e2.png)

## Desired behavior after PR is merged

![ws-new](https://user-images.githubusercontent.com/832627/34910506-d786f70a-f8ae-11e7-86f9-133e70481241.png)


--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
