### PR TITLE
Added spanish as supported language

### DIFF
--- a/src/senaite/lims/profiles/default/portal_languages.xml
+++ b/src/senaite/lims/profiles/default/portal_languages.xml
@@ -14,6 +14,7 @@
   <authenticated_users_only value="False"/>
   <supported_langs>
     <element value="en"/>
+    <element value="es"/>
     <element value="de"/>
   </supported_langs>
 </object>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Adds spanish (es) language support

## Current behavior before PR

No support for spanish. User had to go to ZMI and add spanish manually

## Desired behavior after PR is merged

Spanish appears in top-right language selection list and once selected, the content gets translated to spanish.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
