### PR TITLE
Make Add buttons from AR Add form visible when SENAITE LIMS is active

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,3 +1,19 @@
+1.2.1 (unreleased)
+------------------
+
+**Added**
+
+**Removed**
+
+**Changed**
+
+**Fixed**
+
+- #67 Add buttons from SENAITE HEALTH's Add AR form visible when SENAITE LIMS is active  
+
+**Security**
+
+
 1.2.0 (2018-01-03)
 ------------------
 

--- a/src/senaite/lims/browser/bootstrap/static/css/bootstrap-integration.css
+++ b/src/senaite/lims/browser/bootstrap/static/css/bootstrap-integration.css
@@ -405,3 +405,28 @@ div.overlay div.close {
     opacity: 1;
 }
 /* /Fixture for overlays */
+
+/* Patient and Doctor Add and Edit buttons */
+a.add-button {
+    font-weight: bold;
+    background: transparent url(++resource++bika.lims.images/add.png) left center no-repeat;
+    padding: 8px 8px 8px 10px;
+}
+a.edit-button {
+    font-weight: bold;
+    background: transparent url(++resource++bika.lims.images/edit.png) left center no-repeat;
+    padding: 8px 8px 8px 10px;
+}
+#content a.add-button.referencewidget-add-button.link-overlay,
+#content a.edit-button.referencewidget-edit-button.link-overlay {
+    border-bottom: medium none !important;
+}
+h2 a.add-button {
+    padding: 12px 0 0 38px;
+    background-position: 15px 10px;
+}
+.notext {
+    overflow: hidden;
+    visibility:hidden;
+    display:none;
+}


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.health/issues/59 

When working with SENAITE HEALTH and SENAITE LIMS is active, the add button (+) does not appear next to neither Patient nor the Doctor in the Analysis Request Add form, so the user cannot create new Patients and/or Doctors without leaving the AR Add form.

## Current behavior before PR

When working with SENAITE HEALTH, Patients and Doctors cannot be created from inside the Analysis Request Add form when SENAITE LIMS and is active. The add button (+) is missing.

## Desired behavior after PR is merged

When working with SENAITE HEALTH, Patients and Doctors can be created from inside the Analysis Request Add form when SENAITE LIMS is active. The add button (+) shows up.

## Screenshot (optional)

![seleccio_001](https://user-images.githubusercontent.com/9968427/39117853-2abb2716-46e8-11e8-9ae8-0c290ceffeba.png)


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
