### PR TITLE
Site-Actions Viewlet added

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,8 @@
 
 **Added**
 
+- #75 Site-Actions Viewlet added to Portal footer
+
 **Removed**
 
 - #73 Removed "Add" and "Display" menus

--- a/src/senaite/lims/browser/bootstrap/configure.zcml
+++ b/src/senaite/lims/browser/bootstrap/configure.zcml
@@ -83,6 +83,14 @@
       permission="zope2.View"
       layer="senaite.lims.interfaces.ISenaiteLIMS"/>
 
+  <!-- Site Actions -->
+  <browser:viewlet
+      name="plone.site_actions"
+      manager="plone.app.layout.viewlets.interfaces.IPortalFooter"
+      class=".viewlets.SenaiteSiteActionsViewlet"
+      permission="zope2.View"
+      layer="senaite.lims.interfaces.ISenaiteLIMS"/>
+
   <!-- Document actions -->
   <browser:viewlet
       name="plone.abovecontenttitle.documentactions"

--- a/src/senaite/lims/browser/bootstrap/templates/plone.app.layout.viewlets.site_actions.pt
+++ b/src/senaite/lims/browser/bootstrap/templates/plone.app.layout.viewlets.site_actions.pt
@@ -1,0 +1,35 @@
+<div i18n:domain="senaite"
+     id="portal-siteactions-footer">
+
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12 text-center">
+        <ul class="list-inline"
+            tal:define="accesskeys python: {'sitemap' : '3', 'accessibility' : '0', 'contact' : '9'};"
+            tal:condition="view/site_actions"
+            i18n:domain="plone">
+
+          <li tal:repeat="saction view/site_actions"
+              tal:attributes="id string:siteaction-${saction/id}">
+            <a href=""
+               class=""
+               tal:define="title saction/title;
+                           id saction/id;
+                           accesskey python: accesskeys.get(id, '');"
+               i18n:attributes="title"
+               i18n:translate=""
+               tal:content="title"
+               tal:attributes="href saction/url;
+                              target saction/link_target|nothing;
+                              title title;
+                              accesskey accesskey;">
+              Site action
+            </a>
+          </li>
+        </ul>
+
+      </div>
+    </div>
+  </div>
+
+</div>

--- a/src/senaite/lims/browser/bootstrap/viewlets.py
+++ b/src/senaite/lims/browser/bootstrap/viewlets.py
@@ -18,6 +18,7 @@ from plone.app.layout.viewlets.common import GlobalSectionsViewlet
 from plone.app.layout.viewlets.common import LogoViewlet
 from plone.app.layout.viewlets.common import PathBarViewlet
 from plone.app.layout.viewlets.common import PersonalBarViewlet
+from plone.app.layout.viewlets.common import SiteActionsViewlet
 from plone.app.layout.viewlets.common import ViewletBase
 from plone.app.layout.viewlets.content import DocumentActionsViewlet
 from Products.CMFPlone.utils import safe_unicode
@@ -93,6 +94,11 @@ class SenaitePersonalNavBarViewlet(PersonalBarViewlet):
 class SenaiteContentViewsViewlet(ContentViewsViewlet):
     index = ViewPageTemplateFile(
         'templates/plone.app.layout.viewlets.contentviews.pt')
+
+
+class SenaiteSiteActionsViewlet(SiteActionsViewlet):
+    index = ViewPageTemplateFile(
+        "templates/plone.app.layout.viewlets.site_actions.pt")
 
 
 class SenaiteDocumentActionsViewlet(DocumentActionsViewlet):

--- a/src/senaite/lims/profiles/default/viewlets.xml
+++ b/src/senaite/lims/profiles/default/viewlets.xml
@@ -19,7 +19,6 @@
 
   <!-- Hidden vielets in plone.portalfooter -->
   <hidden manager="plone.portalfooter" skinname="*" purge="True">
-    <viewlet name="plone.site_actions"/>
   </hidden>
 
 </object>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR styles the Site-actions viewlet for bootstrap and makes it also visible by default.

If you want to have it hidden in your site, please consider to make all site-actions in ZMI invisible or use `@@manage-viewlets` to hide them

## Current behavior before PR

Site-actions viewlet was hidden by default and not bootstrap styled

## Desired behavior after PR is merged

Site-actions viewlet is bootstrap styled and visible in footer by default

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
