### PR TITLE
 i18n domain changed from bika->senaite.core

### DIFF
--- a/src/senaite/lims/browser/bootstrap/templates/bika.lims.browser.templates.instrument_qc_failures_viewlet.pt
+++ b/src/senaite/lims/browser/bootstrap/templates/bika.lims.browser.templates.instrument_qc_failures_viewlet.pt
@@ -1,6 +1,6 @@
 <div tal:omit-tag=""
      tal:condition="python:view.nr_failed > 0"
-     i18n:domain="bika">
+     i18n:domain="senaite.core">
 
   <div class="visualClear"><!-- --></div>
 

--- a/src/senaite/lims/browser/bootstrap/templates/bika.lims.browser.viewlets.templates.attachments.pt
+++ b/src/senaite/lims/browser/bootstrap/templates/bika.lims.browser.viewlets.templates.attachments.pt
@@ -1,6 +1,6 @@
 <div id="ar-attachments"
      class="attachments"
-     i18n:domain="bika">
+     i18n:domain="senaite.core">
 
   <p>
     <button type="button"

--- a/src/senaite/lims/browser/bootstrap/templates/bika.lims.browser.viewlets.templates.worksheet_attachments.pt
+++ b/src/senaite/lims/browser/bootstrap/templates/bika.lims.browser.viewlets.templates.worksheet_attachments.pt
@@ -1,6 +1,6 @@
 <div id="ws-attachments"
      class="attachments"
-     i18n:domain="bika">
+     i18n:domain="senaite.core">
 
   <p>
     <button type="button"

--- a/src/senaite/lims/browser/configure.zcml
+++ b/src/senaite/lims/browser/configure.zcml
@@ -1,7 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
-    i18n_domain="senaite">
+    i18n_domain="senaite.lims">
 
   <!-- Package Includes -->
   <include package=".bootstrap"/>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the i18n domain to `senaite.core`

## Current behavior before PR

## Desired behavior after PR is merged

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
