### PR TITLE
Fixed Unauthorized Error caused by Plone's safe_unlock JavaScript

### DIFF
--- a/src/senaite/lims/skins/senaite_templates/main_template.pt
+++ b/src/senaite/lims/skins/senaite_templates/main_template.pt
@@ -54,7 +54,9 @@
                       body_class python:plone_view.bodyClass(template, view);
                       classes python:bootstrapview.getColumnsClasses(view)"
           tal:attributes="class body_class;
-                          dir python:isRTL and 'rtl' or 'ltr'">
+                          dir python: isRTL and 'rtl' or 'ltr';
+                          data-portal-url portal_url;
+                          data-base-url context/absolute_url">
 
       <div id="visual-portal-wrapper" class="container-fluid">
         <div class="row">


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes a traceback which was happening occasionally in the background:

``` 
Unauthorized: You are not allowed to access 'main_template' in this context
```

The issue was related to Plone's `safe_unlock` JavaScript:

```
./Products.CMFPlone-4.3.17-py2.7.egg/Products/CMFPlone/skins/plone_ecmascript/unlockOnFormUnload.js:
   38 :             url: $('body').attr('data-base-url') + '/@@plone_lock_operations/safe_unlock',
   45 :         $.get($('body').attr('data-base-url') + '/@@plone_lock_operations/refresh_lock');
```

However, this attribute was not set in `senaite.lims`

```
>>> $('body').attr('data-base-url')
undefined
```

## Current behavior before PR

Closing or navigating away from a browser tab in an edit view of a content caused this traceback

## Desired behavior after PR is merged

Closing or navigating away from a browser tab causes no more tracebacks

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
