### PR TITLE
Removed Title and Description of Overview Controlpanel

### DIFF
--- a/src/senaite/lims/browser/controlpanel/views/templates/setupview.pt
+++ b/src/senaite/lims/browser/controlpanel/views/templates/setupview.pt
@@ -26,15 +26,6 @@
 
     <div metal:fill-slot="prefs_configlet_main" id="lims-controlpanel">
 
-      <h1 class="documentFirstHeading" i18n:translate="">
-        SENAITE Setup
-      </h1>
-      <p class="documentDescription lead" i18n:translate="">
-        Configuration area for SENAITE LIMS
-      </p>
-
-      <hr/>
-
       <div class="row">
 
         <!-- The setup item -->


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the Title and Description of the overview control panel to safe some space. Also I think it is obvious about what the tiles are all about...

## Current behavior before PR

Title and description displayed on top of the tiles

## Desired behavior after PR is merged

Title and description removed from overview control panel

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
