### PR TITLE
Support for searches against Analysis Requests catalog

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,8 @@
 
 **Added**
 
+- #82 Support for searches against Analysis Requests catalog
+
 **Removed**
 
 **Changed**

--- a/src/senaite/lims/browser/spotlight/jsonapi.py
+++ b/src/senaite/lims/browser/spotlight/jsonapi.py
@@ -5,6 +5,8 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE and CONTRIBUTING.
 
+from bika.lims.catalog.analysisrequest_catalog import \
+    CATALOG_ANALYSIS_REQUEST_LISTING
 from senaite import api
 from senaite.jsonapi import add_route
 
@@ -14,6 +16,7 @@ def spotlight_search_route(context, request):
     """The spotlight search route
     """
     catalogs = [
+        CATALOG_ANALYSIS_REQUEST_LISTING,
         "portal_catalog",
         "bika_setup_catalog",
         "bika_catalog",


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Include AR's catalog in searches

## Current behavior before PR

Searches against ARs-specific catalog not supported

## Desired behavior after PR is merged

Searches against ARs-specific catalog is supported

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
