### PR TITLE
Fix form submission on enter

### DIFF
--- a/src/senaite/lims/browser/spotlight/static/coffee/spotlight.coffee
+++ b/src/senaite/lims/browser/spotlight/static/coffee/spotlight.coffee
@@ -134,6 +134,7 @@ $(document).ready ->
 
     events:
       "keyup #spotlight-search-field": "onKeyup"
+      "keypress #spotlight-search-field": "onKeyup"
       "click #spotlight-clear-button": "onClear"
 
     onClear: (event) =>

--- a/src/senaite/lims/browser/spotlight/static/js/spotlight.js
+++ b/src/senaite/lims/browser/spotlight/static/js/spotlight.js
@@ -206,6 +206,7 @@
 
       SearchView.prototype.events = {
         "keyup #spotlight-search-field": "onKeyup",
+        "keypress #spotlight-search-field": "onKeyup",
         "click #spotlight-clear-button": "onClear"
       };
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the form submission on enter keypress in the searchfield

## Current behavior before PR

If the user presses immediately before any results have been displayed, the form got submitted and nothing was found

## Desired behavior after PR is merged

When the user presses Enter before any results have been displayed, the form stays open or the first result is selected

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
