### PR TITLE
Fix logo link spanning over the whole header

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -11,6 +11,7 @@
 
 **Fixed**
 
+- #85: Fix logo link spanning over the whole header 
 - #84: Fix Spotlight form submission on enter keypress
 
 **Security**

--- a/src/senaite/lims/browser/bootstrap/static/css/bootstrap-integration.css
+++ b/src/senaite/lims/browser/bootstrap/static/css/bootstrap-integration.css
@@ -303,7 +303,7 @@ div.bika-listing-table-top-hooks div.listing-hook-top-wide {
 
 /* Top Navigation */
 #portal-logo img {
-    display: block;
+    display: inline-block;
     margin-top: 20px;
     width: 175px;
     height: auto;


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes that the logo link spans over the whole header and makes all the whitespace around it clickable

## Current behavior before PR

Click on the white space next to the logo navigated back to home

## Desired behavior after PR is merged

Click on the white space next to the logo does no action

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
