### PR TITLE
Do not display setup items with exclude_from_nav setting set to True

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -9,6 +9,8 @@
 
 **Changed**
 
+- #86 Do not display setup items with exclude_from_nav setting set to True
+
 **Fixed**
 
 - #85: Fix logo link spanning over the whole header 

--- a/src/senaite/lims/browser/controlpanel/views/setupview.py
+++ b/src/senaite/lims/browser/controlpanel/views/setupview.py
@@ -79,4 +79,6 @@ class SetupView(BrowserView):
             "sort_on": "sortable_title",
             "sort_order": "ascending"
         }
-        return api.search(query, "portal_catalog")
+        items = api.search(query, "portal_catalog")
+        return filter(lambda item: not item.exclude_from_nav, items)
+


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Make only setup items that are not excluded from navigation visible In `senaite.lims` setup view.

## Current behavior before PR

Setup items for which the setting "exclude_from_nav" have been explicitly set to True are displayed in setup view.

## Desired behavior after PR is merged

Items with "exclude_from_nav" setting set to False are no longer displayed in setup view.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
