### PR TITLE
Stay on current context when switching the language

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -9,9 +9,11 @@
 
 **Changed**
 
+- #87 Stay on current context when switching the language
+
 **Fixed**
 
-- #85: Fix logo link spanning over the whole header 
+- #85: Fix logo link spanning over the whole header
 - #84: Fix Spotlight form submission on enter keypress
 
 **Security**
@@ -26,7 +28,7 @@
 
 **Fixed**
 
-- #79 Fixed Unauthorized Error caused by Plone's safe_unlock JavaScript 
+- #79 Fixed Unauthorized Error caused by Plone's safe_unlock JavaScript
 
 
 1.2.1 (2018-07-10)
@@ -48,7 +50,7 @@
 **Fixed**
 
 - #70 Fixed Tests
-- #67 Add buttons from SENAITE HEALTH's Add AR form visible when SENAITE LIMS is active  
+- #67 Add buttons from SENAITE HEALTH's Add AR form visible when SENAITE LIMS is active
 - #69 Bootstrap fixtures
 
 

--- a/src/senaite/lims/browser/bootstrap/templates/plone.app.i18n.locales.browser.languageselector.pt
+++ b/src/senaite/lims/browser/bootstrap/templates/plone.app.i18n.locales.browser.languageselector.pt
@@ -4,45 +4,38 @@
        style="padding-left: 1em;"
        i18n:domain="plone">
 
+    <!-- Language Button -->
     <button class="btn btn-default dropdown-toggle"
             type="button"
             data-toggle="dropdown"
             aria-haspopup="true"
             aria-expanded="false">
       <span class="glyphicon glyphicon-globe" aria-hidden="true"></span>
-      <span tal:omit-tag="" i18n:translate="">Language</span>
       <span class="caret"></span>
     </button>
 
+    <!-- Available Languages -->
     <ul class="dropdown-menu"
         role="menu"
         aria-labelledby="portal-languageselector"
-        tal:define="showFlags view/showFlags;
-            languages view/languages;
-            here_url context/@@plone_context_state/view_url;
-            portal_url view/portal_url;">
-
+        tal:define="languages view/languages;
+                    base_url context/@@plone_context_state/current_base_url;">
       <tal:language repeat="lang languages">
         <li tal:define="code lang/code;
+                        qs request/QUERY_STRING;
+                        params python:filter(lambda x: x and not x.startswith('set_language'), qs.split('&'));
+                        lang_param string:set_language=${code};
+                        new_params python:'&'.join(params + [lang_param]);
                         selected lang/selected;
                         codeclass string:language-${code};
-                        current python: selected and 'currentLanguage ' or '';"
+                        current python: selected and 'currentLanguage active ' or '';"
             tal:attributes="class string:${current}${codeclass}">
-          <a href=""
-              tal:define="flag lang/flag|nothing;
-                          name lang/native|lang/name;
-                          showflag python:showFlags and flag;"
-              tal:attributes="href string:${here_url}/switchLanguage?set_language=${code};
-                              title name">
-            <tal:flag condition="showflag">
-              <img width="14" height="11" alt=""
-                    tal:attributes="src string:${portal_url}${flag};
-                                    alt name;
-                                    title name;" />
-            </tal:flag>
-            <tal:nonflag condition="not: showflag" replace="name">
-              language name
-            </tal:nonflag>
+          <a href="#"
+             tal:define="name lang/native|lang/name;"
+             tal:attributes="href string:${base_url}?${new_params};
+                             class string:${current} dropdown-item;
+                             title name">
+            <span tal:content="name"/>
           </a>
         </li>
       </tal:language>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Switching the language navigates away from the current context.
Also checks for the flag symbols are included, which consume unnecessary computing time

## Current behavior before PR

Language switch leaves current context

## Desired behavior after PR is merged

Language switch keeps current context

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
