### PR TITLE
Refactored spotlight backend and added more columns to results table

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -9,6 +9,7 @@
 
 **Changed**
 
+- #88 Refactored spotlight backend and added more columns to results table
 - #87 Stay on current context when switching the language
 - #86 Do not display setup items with exclude_from_nav setting set to True
 

--- a/src/senaite/lims/browser/spotlight/static/coffee/spotlight.coffee
+++ b/src/senaite/lims/browser/spotlight/static/coffee/spotlight.coffee
@@ -78,6 +78,8 @@ $(document).ready ->
       icon: ""
       state: ""
       title_or_id: ""
+      parent_title: ""
+      parent_url: ""
 
   # Collection of search results
   class SearchResults extends Backbone.Collection
@@ -230,7 +232,7 @@ $(document).ready ->
       url = "@@API/spotlight/search"
 
       # prepare  the query
-      q = q: query, limit: 10
+      q = q: query, limit: 5
 
       # execute the search
       $.getJSON url, q, (data) =>

--- a/src/senaite/lims/browser/spotlight/static/js/spotlight.js
+++ b/src/senaite/lims/browser/spotlight/static/js/spotlight.js
@@ -107,7 +107,9 @@
         url: "",
         icon: "",
         state: "",
-        title_or_id: ""
+        title_or_id: "",
+        parent_title: "",
+        parent_url: ""
       };
 
       return SearchResult;
@@ -296,7 +298,7 @@
         url = "@@API/spotlight/search";
         q = {
           q: query,
-          limit: 10
+          limit: 5
         };
         return $.getJSON(url, q, (function(_this) {
           return function(data) {

--- a/src/senaite/lims/browser/spotlight/templates/spotlight_viewlet.pt
+++ b/src/senaite/lims/browser/spotlight/templates/spotlight_viewlet.pt
@@ -37,6 +37,8 @@
         <tr>
           <th></th>
           <th i18n:translate="">Title</th>
+          <th i18n:translate="">ID</th>
+          <th i18n:translate="">Location</th>
           <th i18n:translate="">Description</th>
         </tr>
       </thead>
@@ -50,6 +52,12 @@
     </td>
     <td>
       <a class="link" href="<%- url %>"><%- title_or_id %></a>
+    </td>
+    <td>
+      <a class="link" href="<%- url %>"><%- id %></a>
+    </td>
+    <td>
+      <a class="link" href="<%- parent_url %>"><%- parent_title %></a>
     </td>
     <td>
       <span><%- description %></span>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds the columns "ID" and "Location" to the results table. Furthermore, the `listing_searchable_text` index is queried for the `bika_catalog_analysisrequest_listing` catalog (if available). Some refactorings were done as well

## Current behavior before PR

- Results table did not show ID and Location
- Only SearchableText index was queried

## Desired behavior after PR is merged

- Results table shows ID and Location columns
- `listing_searchable_text` index is used for `bika_catalog_analysisrequest_listing` catalog searches

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
