### PR TITLE
Removed unneeded data from JSON data

### DIFF
--- a/src/senaite/lims/browser/spotlight/jsonapi.py
+++ b/src/senaite/lims/browser/spotlight/jsonapi.py
@@ -49,7 +49,6 @@ def get_brain_info(brain):
 
     id = api.get_id(brain)
     url = api.get_url(brain)
-    path = api.get_path(brain)
     title = api.get_title(brain)
     description = api.get_description(brain)
     parent = api.get_parent(brain)
@@ -61,7 +60,6 @@ def get_brain_info(brain):
         "title": title,
         "title_or_id": title or id,
         "description": description,
-        "path": path,
         "url": url,
         "parent_title": parent_title,
         "parent_url": parent_url,

--- a/src/senaite/lims/browser/spotlight/jsonapi.py
+++ b/src/senaite/lims/browser/spotlight/jsonapi.py
@@ -48,7 +48,6 @@ def get_brain_info(brain):
         icon = ""
 
     id = api.get_id(brain)
-    uid = api.get_uid(brain)
     url = api.get_url(brain)
     path = api.get_path(brain)
     title = api.get_title(brain)
@@ -56,19 +55,16 @@ def get_brain_info(brain):
     parent = api.get_parent(brain)
     parent_title = api.get_title(parent)
     parent_url = api.get_url(parent)
-    state = api.get_review_status(brain)
 
     return {
         "id": id,
         "title": title,
         "title_or_id": title or id,
         "description": description,
-        "uid": uid,
         "path": path,
         "url": url,
         "parent_title": parent_title,
         "parent_url": parent_url,
-        "state": state,
         "icon": icon,
     }
 

--- a/src/senaite/lims/browser/spotlight/static/coffee/spotlight.coffee
+++ b/src/senaite/lims/browser/spotlight/static/coffee/spotlight.coffee
@@ -76,7 +76,6 @@ $(document).ready ->
       title: ""
       url: ""
       icon: ""
-      state: ""
       title_or_id: ""
       parent_title: ""
       parent_url: ""

--- a/src/senaite/lims/browser/spotlight/static/js/spotlight.js
+++ b/src/senaite/lims/browser/spotlight/static/js/spotlight.js
@@ -106,7 +106,6 @@
         title: "",
         url: "",
         icon: "",
-        state: "",
         title_or_id: "",
         parent_title: "",
         parent_url: ""


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes unneeded data from the Spotlight response JSON data

## Current behavior before PR

WF state, path and UID were returned, although unneeded

## Desired behavior after PR is merged

WF state, path and UID omitted from the JSON

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
