### PR TITLE
Fix CSS class for portal message in control-panel

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -16,6 +16,7 @@
 
 **Fixed**
 
+- #91: Fix CSS class for portal message in control-panel
 - #85: Fix logo link spanning over the whole header
 - #84: Fix Spotlight form submission on enter keypress
 

--- a/src/senaite/lims/browser/bootstrap/static/coffee/bootstrap-integration.coffee
+++ b/src/senaite/lims/browser/bootstrap/static/coffee/bootstrap-integration.coffee
@@ -103,6 +103,7 @@ class Bootstrap
 
     mapping =
       "error": "danger"
+      "warn": "warning"
 
     if remove_others
       # remove all previous error messages
@@ -112,7 +113,7 @@ class Bootstrap
     cls = $el[0].className
     title = $el.find("dt").html()
     message = $el.find("dd").html()
-    facility = mapping[cls] if cls of mapping or cls
+    facility = if cls of mapping then mapping[cls] else cls
     replacement = $("""
       <div data-alert="alert" class="alert alert-dismissible alert-#{facility}">
         <button type="button" class="close" data-dismiss="alert" aria-label="Close">

--- a/src/senaite/lims/browser/bootstrap/static/js/bootstrap-integration.js
+++ b/src/senaite/lims/browser/bootstrap/static/js/bootstrap-integration.js
@@ -78,7 +78,8 @@
         return;
       }
       mapping = {
-        "error": "danger"
+        "error": "danger",
+        "warn": "warning"
       };
       if (remove_others) {
         $("#viewlet-above-content div[data-alert='alert']").remove();
@@ -87,9 +88,7 @@
       cls = $el[0].className;
       title = $el.find("dt").html();
       message = $el.find("dd").html();
-      if (cls in mapping || cls) {
-        facility = mapping[cls];
-      }
+      facility = cls in mapping ? mapping[cls] : cls;
       replacement = $("<div data-alert=\"alert\" class=\"alert alert-dismissible alert-" + facility + "\">\n  <button type=\"button\" class=\"close\" data-dismiss=\"alert\" aria-label=\"Close\">\n    <span aria-hidden=\"true\">×</span>\n  </button>\n  <strong>" + title + "</strong>\n  <p>" + message + "</p>\n</div>");
       replacement.attr("style", $el.attr("style"));
       return $el.replaceWith(replacement);


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the portal message CSS class in the control panels 

## Current behavior before PR

<img width="806" alt="senaite 2018-12-24 20-31-24" src="https://user-images.githubusercontent.com/713193/50405875-7386be80-07bb-11e9-95a9-f8b3cbb0f685.png">

## Desired behavior after PR is merged

<img width="815" alt="senaite 2018-12-24 20-35-55" src="https://user-images.githubusercontent.com/713193/50405881-86998e80-07bb-11e9-9762-71ba58490d1b.png">

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
