### PR TITLE
Flatten the first heading from content a bit

### DIFF
--- a/src/senaite/lims/browser/bootstrap/static/css/bootstrap-integration.css
+++ b/src/senaite/lims/browser/bootstrap/static/css/bootstrap-integration.css
@@ -372,3 +372,9 @@ h2 a.add-button {
     padding: 12px 0 0 38px;
     background-position: 15px 10px;
 }
+
+/* Flatten the first heading from content a bit
+https://github.com/senaite/senaite.lims/pull/92 */
+#content > h1:first-of-type {
+    margin-top: 0;
+}


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Flatten the first header from content section a little bit to align with nav bar

## Current behavior before PR

![captura de pantalla de 2019-01-10 00-22-37](https://user-images.githubusercontent.com/832627/50936090-9200e100-146e-11e9-8db0-2779ed1a21e6.png)


## Desired behavior after PR is merged

![captura de pantalla de 2019-01-10 00-23-07](https://user-images.githubusercontent.com/832627/50936095-975e2b80-146e-11e9-954b-bf42b1af9b23.png)

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
