### PR TITLE
Bootstrapped TinyMCE

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,4 +1,4 @@
-1.2.3 (unreleased)
+1.3.0 (unreleased)
 ------------------
 
 **Added**

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -16,6 +16,7 @@
 
 **Fixed**
 
+- #96: Bootstrapped TinyMCE
 - #91: Fix CSS class for portal message in control-panel
 - #85: Fix logo link spanning over the whole header
 - #84: Fix Spotlight form submission on enter keypress

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-version = "1.2.3"
+version = "1.3.0"
 
 with open("docs/About.rst", "r") as fh:
     long_description = fh.read()
@@ -40,8 +40,10 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        "senaite.core>=1.3.0",
         "senaite.api",
+        "senaite.core.listing>=1.0.0",
+        "senaite.core>=1.3.0",
+        "senaite.impress",
         "senaite.jsonapi",
         "setuptools",
     ],

--- a/src/senaite/lims/profiles/default/tinymce.xml
+++ b/src/senaite/lims/profiles/default/tinymce.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0"?>
+<object>
+ <resourcetypes>
+  <linkable>
+   <element value="AnalysisRequest"/>
+   <element value="Client"/>
+  </linkable>
+  <customplugins>
+   <element value="plonebrowser"/>
+  </customplugins>
+  <containsanchors>
+   <element value="AnalysisRequest"/>
+  </containsanchors>
+  <allow_captioned_images value="False"/>
+  <plugins>
+   <element value="advhr"/>
+   <element value="definitionlist"/>
+   <element value="directionality"/>
+   <element value="emotions"/>
+   <element value="fullscreen"/>
+   <element value="inlinepopups"/>
+   <element value="insertdatetime"/>
+   <element value="media"/>
+   <element value="nonbreaking"/>
+   <element value="noneditable"/>
+   <element value="pagebreak"/>
+   <element value="paste"/>
+   <element value="plonebrowser"/>
+   <element value="ploneinlinestyles"/>
+   <element value="plonestyle"/>
+   <element value="preview"/>
+   <element value="print"/>
+   <element value="save"/>
+   <element value="searchreplace"/>
+   <element value="tabfocus"/>
+   <element value="table"/>
+   <element value="visualchars"/>
+   <element value="xhtmlxtras"/>
+  </plugins>
+  <containsobjects>
+   <element value="Folder"/>
+   <element value="Large Plone Folder"/>
+   <element value="Plone Site"/>
+  </containsobjects>
+  <entity_encoding value="raw"/>
+  <imageobjects>
+   <element value="Attachment"/>
+  </imageobjects>
+  <link_using_uids value="True"/>
+  <rooted value="False"/>
+ </resourcetypes>
+ <contentbrowser>
+  <anchor_selector value="h2,h3"/>
+  <image_shortcuts>
+   <element value="Home"/>
+   <element value="Current Folder"/>
+  </image_shortcuts>
+  <link_shortcuts>
+   <element value="Home"/>
+   <element value="Current Folder"/>
+  </link_shortcuts>
+ </contentbrowser>
+ <layout>
+  <styles value=""/>
+  <tablestyles>
+   <element value="Full-width|table"/>
+   <element value="Condensed|table-condensed"/>
+   <element value="Striped|table-striped"/>
+   <element value="Bordered|table-bordered"/>
+  </tablestyles>
+  <content_css
+     value="++resource++senaite.lims.bootstrap.vendor/css/bootstrap.min.css"/>
+  <editor_height value="600"/>
+  <editor_width value="100%"/>
+  <contextmenu value="True"/>
+  <tablerowstyles>
+  </tablerowstyles>
+  <resizing value="True"/>
+  <autoresize value="False"/>
+ </layout>
+ <toolbar>
+  <toolbar_anchor value="True"/>
+  <toolbar_hr value="False"/>
+  <toolbar_insertdate value="False"/>
+  <toolbar_cut value="False"/>
+  <toolbar_definitionlist value="True"/>
+  <customtoolbarbuttons value=""/>
+  <toolbar_paste value="False"/>
+  <toolbar_justifycenter value="True"/>
+  <toolbar_inserttime value="False"/>
+  <toolbar_tablecontrols value="True"/>
+  <toolbar_justifyleft value="True"/>
+  <toolbar_redo value="False"/>
+  <toolbar_unlink value="True"/>
+  <toolbar_visualchars value="False"/>
+  <toolbar_media value="False"/>
+  <toolbar_nonbreaking value="False"/>
+  <toolbar_image value="True"/>
+  <toolbar_advhr value="False"/>
+  <toolbar_removeformat value="True"/>
+  <toolbar_undo value="False"/>
+  <toolbar_save value="True"/>
+  <toolbar_sub value="True"/>
+  <toolbar_numlist value="True"/>
+  <toolbar_underline value="True"/>
+  <toolbar_sup value="True"/>
+  <toolbar_preview value="False"/>
+  <toolbar_forecolor value="True"/>
+  <toolbar_code value="True"/>
+  <toolbar_style value="True"/>
+  <toolbar_link value="True"/>
+  <toolbar_emotions value="False"/>
+  <toolbar_justifyright value="True"/>
+  <toolbar_replace value="False"/>
+  <toolbar_outdent value="True"/>
+  <toolbar_strikethrough value="False"/>
+  <toolbar_pasteword value="True"/>
+  <toolbar_width value="440"/>
+  <toolbar_print value="False"/>
+  <toolbar_spellchecker value="False"/>
+  <toolbar_justifyfull value="True"/>
+  <toolbar_charmap value="False"/>
+  <toolbar_bullist value="True"/>
+  <toolbar_copy value="False"/>
+  <toolbar_pastetext value="False"/>
+  <toolbar_visualaid value="False"/>
+  <toolbar_indent value="True"/>
+  <toolbar_search value="False"/>
+  <toolbar_fullscreen value="True"/>
+  <toolbar_italic value="True"/>
+  <toolbar_attribs value="False"/>
+  <toolbar_pagebreak value="False"/>
+  <toolbar_bold value="True"/>
+  <toolbar_backcolor value="True"/>
+  <toolbar_external value="False"/>
+  <toolbar_cleanup value="False"/>
+ </toolbar>
+</object>

--- a/src/senaite/lims/setuphandlers.py
+++ b/src/senaite/lims/setuphandlers.py
@@ -5,7 +5,13 @@
 # Copyright 2018 by it's authors.
 # Some rights reserved. See LICENSE and CONTRIBUTING.
 
+from plone.app.controlpanel.filter import IFilterSchema
 from senaite.lims import logger
+
+ALLOWED_STYLES = [
+    "color",
+    "background-color"
+]
 
 
 def setup_handler(context):
@@ -17,7 +23,25 @@ def setup_handler(context):
 
     logger.info("SENAITE setup handler [BEGIN]")
     portal = context.getSite()  # noqa
+
+    # Custom setup handlers
+    setup_html_filter(portal)
+
     logger.info("SENAITE setup handler [DONE]")
+
+
+def setup_html_filter(portal):
+    """Setup HTML filtering for resultsinterpretations
+    """
+    logger.info("*** Setup HTML Filter ***")
+    # bypass the broken API from portal_transforms
+    adapter = IFilterSchema(portal)
+    style_whitelist = adapter.style_whitelist
+    for style in ALLOWED_STYLES:
+        logger.info("Allow style '{}'".format(style))
+        if style not in style_whitelist:
+            style_whitelist.append(style)
+    adapter.style_whitelist = style_whitelist
 
 
 def post_install(portal_setup):

--- a/src/senaite/lims/upgrade/configure.zcml
+++ b/src/senaite/lims/upgrade/configure.zcml
@@ -4,10 +4,10 @@
     i18n_domain="senaite.lims">
 
   <genericsetup:upgradeStep
-      title="Upgrade to SENAITE LIMS 1.2.3"
+      title="Upgrade to SENAITE LIMS 1.3.0"
       source="1.2.2"
-      destination="1.2.3"
-      handler="senaite.lims.upgrade.v01_02_003.upgrade"
+      destination="1.3.0"
+      handler="senaite.lims.upgrade.v01_03_000.upgrade"
       profile="senaite.lims:default"/>
 
   <genericsetup:upgradeStep

--- a/src/senaite/lims/upgrade/v01_03_000.py
+++ b/src/senaite/lims/upgrade/v01_03_000.py
@@ -11,8 +11,10 @@ from bika.lims import logger
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
 from senaite.lims.config import PROJECTNAME as product
+from senaite.lims.setuphandlers import setup_html_filter
 
-version = "1.2.3"
+
+version = "1.3.0"
 profile = "profile-{0}:default".format(product)
 
 
@@ -32,6 +34,9 @@ def upgrade(tool):
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
     run_all_import_steps(portal)
+
+    # setup HTML filtering
+    setup_html_filter(portal)
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR customizes the TinyMCE styles to be compatible with the new Bootstrap styles.
Linked Issue: https://github.com/senaite/senaite.lims/issues/59

## Current behavior before PR

Plone styles were used and some inline styles were stripped off on save

## Desired behavior after PR is merged

Bootstrap CSS is used inside TinyMCE, HTML filtering updated, enabled some TinyMCE buttons


--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
