### PR TITLE
Sort setup items by translated title

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -9,6 +9,7 @@
 
 **Changed**
 
+- #97 Sort setup items by translated title
 - #90 Integration for senaite.core 1.3
 - #88 Refactored spotlight backend and added more columns to results table
 - #87 Stay on current context when switching the language

--- a/src/senaite/lims/browser/controlpanel/views/setupview.py
+++ b/src/senaite/lims/browser/controlpanel/views/setupview.py
@@ -7,6 +7,7 @@
 
 import os
 
+from bika.lims.utils import t
 from plone.memoize.volatile import cache
 from plone.memoize.volatile import store_on_context
 from Products.Five.browser import BrowserView
@@ -76,9 +77,15 @@ class SetupView(BrowserView):
                 "query": api.get_path(self.setup),
                 "depth": 1,
             },
-            "sort_on": "sortable_title",
-            "sort_order": "ascending"
         }
         items = api.search(query, "portal_catalog")
-        return filter(lambda item: not item.exclude_from_nav, items)
+        # filter out items
+        items = filter(lambda item: not item.exclude_from_nav, items)
 
+        # sort by (translated) title
+        def cmp_by_translated_title(brain1, brain2):
+            title1 = t(api.get_title(brain1))
+            title2 = t(api.get_title(brain2))
+            return cmp(title1, title2)
+
+        return sorted(items, cmp=cmp_by_translated_title)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR sorts the setup items (tiles) alphabetically

## Current behavior before PR

Setup items sorted by english title

## Desired behavior after PR is merged

Setup items sorted by translated title

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
