### PR TITLE
Improve Styling of Navigation Portlet

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -10,6 +10,7 @@
 
 **Changed**
 
+- #100 Improve Styling of Navigation Portlet
 - #97 Sort setup items by translated title
 - #90 Integration for senaite.core 1.3
 - #88 Refactored spotlight backend and added more columns to results table

--- a/src/senaite/lims/browser/bootstrap/static/css/bootstrap-integration.css
+++ b/src/senaite/lims/browser/bootstrap/static/css/bootstrap-integration.css
@@ -276,6 +276,13 @@ table.analysisrequest.add {}
     max-height: none;
     padding: 0;
 }
+.sidebar-nav .navbar-nav {
+    margin: 0;
+}
+.sidebar-nav li a>* {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
 .sidebar-nav .navbar ul {
     float: none;
 }

--- a/src/senaite/lims/browser/bootstrap/templates/plone.app.portlets.portlets.navigation.pt
+++ b/src/senaite/lims/browser/bootstrap/templates/plone.app.portlets.portlets.navigation.pt
@@ -13,9 +13,8 @@
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
         </button>
-        <span class="visible-xs navbar-brand"
-              i18n:translate="">
-          SENAITE
+        <span class="visible-xs navbar-brand" tal:content="view/title">
+          Navigation
         </span>
       </div>
 

--- a/src/senaite/lims/browser/bootstrap/templates/plone.app.portlets.portlets.navigation_recurse.pt
+++ b/src/senaite/lims/browser/bootstrap/templates/plone.app.portlets.portlets.navigation_recurse.pt
@@ -1,6 +1,7 @@
 <tal:master define="level options/level|python:0;
                     children options/children | nothing;
-                    bottomLevel options/bottomLevel | nothing;"
+                    bottomLevel options/bottomLevel | nothing;
+                    bootstrapview nocall:context/@@bootstrapview"
             i18n:domain="plone">
 
   <metal:main define-macro="nav_main">
@@ -12,7 +13,8 @@
                       item_url        node/getURL;
                       item_remote_url node/getRemoteUrl;
                       use_remote_url  node/useRemoteUrl | nothing;
-                      item_icon       nocall:node/item_icon;
+                      item            nocall:node/item;
+                      item_icon       python:bootstrapview.get_icon_for(item);
                       item_type       node/portal_type;
                       is_current      node/currentItem;
                       is_in_path      node/currentParent;
@@ -31,15 +33,17 @@
                              title node/Description;
                              class string:$item_class${li_class}${li_extr_class}${li_folder_class} $item_type_class">
             <tal:root tal:condition="python: level==1">
-              <img tal:replace="structure item_icon/html_tag" />
+              <img tal:replace="structure item_icon"/>
               <span tal:condition="not:item_icon">
                 <span class="glyphicon glyphicon-folder-close" aria-hidden="true"></span>
               </span>
               <span tal:replace="node/Title">Selected Item Title</span>
             </tal:root>
             <tal:children tal:condition="python: level>1">
-              <span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span>
-              <span tal:replace="node/Title">Selected Item Title</span>
+              <div style="white-space:nowrap;">
+                <span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span>
+                <span tal:replace="node/Title">Selected Item Title</span>
+              </div>
             </tal:children>
           </a>
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR improves the appearance of the navigation portlet for desktop/mobile devices

## Current behavior before PR

- blurry icons on high-res displays (4K and above)
- No padding of items in mobile view
- submenu overflow

## Desired behavior after PR is merged

- crisp icons for high-res displays
- propper item padding in mobile view
- submenu items do not break after the icon and overflow with ellipsis

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
