### PR TITLE
Improved navigation portlet icon lookup cache

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
-1.4.0 (unreleased)
+1.3.1 (unreleased)
 ------------------
 
-- no changes yet
+- #102 Improved navigation portlet icon lookup cache
 
 
 1.3.0 (2019-03-30)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-version = "1.4.0"
+version = "1.3.1"
 
 with open("docs/About.rst", "r") as fh:
     long_description = fh.read()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR improves the cache key for the navigation portlet icons to handle multiple domains.

## Current behavior before PR

Icons were not displayed when the site was accessed by different HTTP/HTTPS domains

## Desired behavior after PR is merged

Icons are displayed and cached for each domain name individually

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
