### PR TITLE
Capitalize WF state titles for better translation handling

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 1.3.2 (unreleased)
 ------------------
 
-- no changes yet
+- #104: Capitalize WF state titles for better translation handling
 
 
 1.3.1 (2019-07-01)

--- a/src/senaite/lims/browser/bootstrap/templates/plone.app.contentmenu.contentmenu.pt
+++ b/src/senaite/lims/browser/bootstrap/templates/plone.app.contentmenu.contentmenu.pt
@@ -26,7 +26,8 @@
           </span>
           <span tal:condition="menuItem/extra/stateTitle | nothing"
                 tal:attributes="class menuItem/extra/class | nothing"
-                tal:content="menuItem/extra/stateTitle"
+                tal:define="title menuItem/extra/stateTitle"
+                tal:content="python:title.capitalize()"
                 i18n:translate="">
             State title
           </span>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is a quick-fix for partly untranslated state titles in the WF action menu.
However, the reason for this needs to be finally fixed in the WF definitions to specify everywhere the correct capitalized state titles

## Current behavior before PR

State titles not translated, because the lower case State ID is used

## Desired behavior after PR is merged

State titles translated, because the state IDs are capitalized before rendering 

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
