### PR TITLE
Remove fix-remarks-field

### DIFF
--- a/src/senaite/lims/browser/bootstrap/static/coffee/bootstrap-integration.coffee
+++ b/src/senaite/lims/browser/bootstrap/static/coffee/bootstrap-integration.coffee
@@ -153,28 +153,6 @@ class Bootstrap
     @activate_form_tabbing $el
 
 
-  fix_remarks_field: (el) ->
-    console.debug "Bootstrap::fix_remarks_field"
-
-    $el = $(el)
-
-    if $el.attr("id") isnt "archetypes-fieldname-Remarks"
-      console.error "Element is not a remarks field"
-      return
-
-    $el.css "padding-top", "2em"
-    $el.find("fieldset legend").css "margin", "0 0 0 0"
-    $el.find("fieldset legend").css "padding", "1em 0 0 0"
-    # Remarks text
-    remarks = $el.find "fieldset span"
-    remarks.find("br").remove()
-    remarks.addClass "text-danger"
-    remarks.css "font-size", "100%"
-    remarks.css "font-weight", "bold"
-    remarks.html (index, html) ->
-      html.replace /===/g, "<br/>☞"
-
-
   fix_manage_viewlets: (el) ->
     console.debug "Bootstrap::fix_manage_viewlets"
 
@@ -252,11 +230,6 @@ $(document).ready ->
   $(document).on "onCreate", (event, el) ->
     $el = $(el)
 
-    if $el.text().startsWith "==="
-      remarks = $el.closest "#archetypes-fieldname-Remarks"
-      if remarks.length > 0
-        bs.fix_remarks_field remarks
-
     if $el.hasClass("portalMessage")
       bs.fix_portal_message $el
 
@@ -275,10 +248,6 @@ $(document).ready ->
   # Fix all results interpretations
   $("div.arresultsinterpretation-container").each ->
     bs.fix_results_interpretation this
-
-  # Fix remarks field
-  $("#archetypes-fieldname-Remarks").each ->
-    bs.fix_remarks_field this
 
   # Fix all form tabs
   $("ul.formTabs").each ->

--- a/src/senaite/lims/browser/bootstrap/static/js/bootstrap-integration.js
+++ b/src/senaite/lims/browser/bootstrap/static/js/bootstrap-integration.js
@@ -120,27 +120,6 @@
       return this.activate_form_tabbing($el);
     };
 
-    Bootstrap.prototype.fix_remarks_field = function(el) {
-      var $el, remarks;
-      console.debug("Bootstrap::fix_remarks_field");
-      $el = $(el);
-      if ($el.attr("id") !== "archetypes-fieldname-Remarks") {
-        console.error("Element is not a remarks field");
-        return;
-      }
-      $el.css("padding-top", "2em");
-      $el.find("fieldset legend").css("margin", "0 0 0 0");
-      $el.find("fieldset legend").css("padding", "1em 0 0 0");
-      remarks = $el.find("fieldset span");
-      remarks.find("br").remove();
-      remarks.addClass("text-danger");
-      remarks.css("font-size", "100%");
-      remarks.css("font-weight", "bold");
-      return remarks.html(function(index, html) {
-        return html.replace(/===/g, "<br/>☞");
-      });
-    };
-
     Bootstrap.prototype.fix_manage_viewlets = function(el) {
       var $el, hiddenviewlet;
       console.debug("Bootstrap::fix_manage_viewlets");
@@ -209,14 +188,8 @@
       subtree: true
     });
     $(document).on("onCreate", function(event, el) {
-      var $el, remarks;
+      var $el;
       $el = $(el);
-      if ($el.text().startsWith("===")) {
-        remarks = $el.closest("#archetypes-fieldname-Remarks");
-        if (remarks.length > 0) {
-          bs.fix_remarks_field(remarks);
-        }
-      }
       if ($el.hasClass("portalMessage")) {
         return bs.fix_portal_message($el);
       }
@@ -232,9 +205,6 @@
     });
     $("div.arresultsinterpretation-container").each(function() {
       return bs.fix_results_interpretation(this);
-    });
-    $("#archetypes-fieldname-Remarks").each(function() {
-      return bs.fix_remarks_field(this);
     });
     $("ul.formTabs").each(function() {
       return bs.fix_form_tabs(this);


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request removes the code that modifies how the remarks are displayed. This code is no longer necessary because of https://github.com/senaite/senaite.core/pull/1495

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
