### PR TITLE
Remove dependency to Products.TextIndexNG3 (test layer)

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 2.3.0 (unreleased)
 ------------------
 
-- no changes yet
+- #132 Remove dependency to Products.TextIndexNG3 (test layer)
 
 
 2.2.0 (2022-06-11)

--- a/src/senaite/lims/tests/base.py
+++ b/src/senaite/lims/tests/base.py
@@ -42,7 +42,6 @@ class SimpleTestLayer(PloneSandboxLayer):
         super(SimpleTestLayer, self).setUpZope(app, configurationContext)
 
         # Load ZCML
-        import Products.TextIndexNG3
         import bika.lims
         import senaite.core
         import senaite.lims
@@ -50,7 +49,6 @@ class SimpleTestLayer(PloneSandboxLayer):
         import senaite.app.listing
         import senaite.app.spotlight
 
-        self.loadZCML(package=Products.TextIndexNG3)
         self.loadZCML(package=bika.lims)
         self.loadZCML(package=senaite.core)
         self.loadZCML(package=senaite.lims)
@@ -59,7 +57,6 @@ class SimpleTestLayer(PloneSandboxLayer):
         self.loadZCML(package=senaite.app.spotlight)
 
         # Install product and call its initialize() function
-        zope.installProduct(app, "Products.TextIndexNG3")
         zope.installProduct(app, "bika.lims")
         zope.installProduct(app, "senaite.core")
         zope.installProduct(app, "senaite.app.listing")


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request removes the `Products.TextIndexNG3` dependency on the test layer because it is no longer a SENAITE dependency as per https://github.com/senaite/senaite.core/pull/2011 and https://github.com/senaite/senaite.core/pull/2014

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
